### PR TITLE
Specify AuthToken as parent class of APIToken and JWTAuthToken in order

### DIFF
--- a/nocodb/nocodb.py
+++ b/nocodb/nocodb.py
@@ -32,7 +32,7 @@ class AuthToken(ABC):
         pass
 
 
-class APIToken:
+class APIToken(AuthToken):
     def __init__(self, token: str):
         self.__token = token
 
@@ -40,7 +40,7 @@ class APIToken:
         return {"xc-token": self.__token}
 
 
-class JWTAuthToken:
+class JWTAuthToken(AuthToken):
     def __init__(self, token: str):
         self.__token = token
 


### PR DESCRIPTION
This omits the Pyright warning when an APIToken/JWAuthToken is used in the creation of a new NocoDBRequests instance. As there is currently no no way for Pyright to tell that this to classes can be used as a parameter for NocoDBRequsts.