### PR TITLE
Adds the ability to upload local files and associate them with an attachment field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ client.table_row_update(project, table_name, row_id, row_info)
 
 # Delete a row (only if you've already bought me a beer)
 client.table_row_delete(project, table_name, row_id)
+
+# Upload a file to an attachment field
+image_path = "path/to/new_car.png"
+image_column = "images"
+client.upload_file(project, table, row_id, image_column, image_path)
 ```
 
 ### Available filters

--- a/nocodb/api.py
+++ b/nocodb/api.py
@@ -6,12 +6,14 @@ from .nocodb import NocoDBProject
 class NocoDBAPIUris(Enum):
     V1_DB_DATA_PREFIX = "api/v1/db/data/"
     V1_DB_META_PREFIX = "api/v1/db/meta/"
+    V1_DB_STORAGE_PREFIX = "api/v1/db/storage/"
 
 
 class NocoDBAPI:
     def __init__(self, base_uri: str):
         self.__base_data_uri = urljoin(base_uri + "/", NocoDBAPIUris.V1_DB_DATA_PREFIX.value)
         self.__base_meta_uri = urljoin(base_uri + "/", NocoDBAPIUris.V1_DB_META_PREFIX.value)
+        self.__base_storage_uri = urljoin(base_uri + "/", NocoDBAPIUris.V1_DB_STORAGE_PREFIX.value)
 
     def get_table_uri(self, project: NocoDBProject, table: str) -> str:
         return urljoin(self.__base_data_uri, "/".join(
@@ -84,6 +86,24 @@ class NocoDBAPI:
                 "tables"
             )
         ))
+
+    def get_storage_upload_uri(
+        self,
+    ) -> str:
+        return urljoin(self.__base_storage_uri, "upload")
+    
+    def get_storage_upload_path(
+        self, project: NocoDBProject, table: str, column_id: str,
+    ) -> str:
+        """This Path/URL is used in the request body for uploading attachments."""
+        return urljoin(f"{project.org_name}/", "/".join(
+            [
+                project.project_name,
+                table,
+                column_id,
+            ]
+        ))
+
     
     def get_table_meta_uri(
         self, tableId: str, operation: str = None,

--- a/nocodb/nocodb.py
+++ b/nocodb/nocodb.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional
 
 """
@@ -172,4 +173,10 @@ class NocoDBClient:
     def table_column_set_primary(
         self, columnId: str,
     ) -> dict:
+        pass
+
+    @abstractmethod
+    def upload_file(
+        self, project: NocoDBProject, table: str, row_id: int, column_id: str, file: Path
+    ):
         pass


### PR DESCRIPTION
The new upload_file method allows a local file to be uploaded to NocoDB and assigned to a field with the attachment type. The upload is done in two steps: First, the file is transferred to the NocoDB server using the upload endpoint (https://apis.nocodb.com/#tag/Storage/operation/storage-upload) of the Meta-Api. Then, with the help of table_row_update, the specified field is linked to the uploaded file.