### PR TITLE
feat: refactor logical filters and add tests

### DIFF
--- a/nocodb/filters/logical.py
+++ b/nocodb/filters/logical.py
@@ -7,11 +7,7 @@ class Or(WhereFilter):
         self.__filters = filters
 
     def get_where(self) -> str:
-        return (
-            "("
-            + "~or".join([filter.get_where() for filter in self.__filters])
-            + ")"
-        )
+        return f"({'~or'.join([filter.get_where() for filter in self.__filters])})"
 
 
 class And(WhereFilter):
@@ -19,11 +15,7 @@ class And(WhereFilter):
         self.__filters = filters
 
     def get_where(self) -> str:
-        return (
-            "("
-            + "~and".join([filter.get_where() for filter in self.__filters])
-            + ")"
-        )
+        return f"({'~and'.join([filter.get_where() for filter in self.__filters])})"
 
 
 class Not(WhereFilter):
@@ -31,4 +23,4 @@ class Not(WhereFilter):
         self.__filter = filter
 
     def get_where(self) -> str:
-        return "~not" + self.__filter.get_where()
+        return f"~not{self.__filter.get_where()}"

--- a/nocodb/filters/logical_test.py
+++ b/nocodb/filters/logical_test.py
@@ -1,0 +1,21 @@
+from nocodb import filters
+
+
+def test_or_with_two_filters():
+    filter1 = filters.EqFilter("column1", "value1")
+    filter2 = filters.EqFilter("column2", "value2")
+    or_filter = filters.Or(filter1, filter2)
+    assert or_filter.get_where() == "((column1,eq,value1)~or(column2,eq,value2))"
+
+
+def test_and_with_two_filters():
+    filter1 = filters.And(filters.EqFilter("column1", "value1"))
+    filter2 = filters.And(filters.EqFilter("column2", "value2"))
+    and_filter = filters.And(filter1, filter2)
+    assert and_filter.get_where() == "(((column1,eq,value1))~and((column2,eq,value2)))"
+
+
+def test_not_filter():
+    filter = filters.EqFilter("column", "value")
+    not_filter = filters.Not(filter)
+    assert not_filter.get_where() == "~not(column,eq,value)"


### PR DESCRIPTION
Refactor logical filters and add tests to address #8 

This pull request simplifies the implementation of the logical filters (Or, And, Not) by using f-strings instead of concatenation. It also adds unit tests for the logical filters in a new file called logical_test.py.

The purpose of this pull request is to improve the readability and maintainability of the filter module, as well as to increase the test coverage.

To test this pull request, you can run the logical_test.py file and verify that all the tests pass.